### PR TITLE
Allow duplicate keys

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.0.3"
+current_version = "v0.0.4"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "refractiveindex2"
-version = "v0.0.3"
+version = "v0.0.4"
 description = "A python interface to the refractiveindex.info database."
 keywords = []
 readme = "README.md"

--- a/src/refractiveindex2/__init__.py
+++ b/src/refractiveindex2/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2025 Martin F. Scubert
 """
 
-__version__ = "v0.0.3"
+__version__ = "v0.0.4"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from .refractiveindex import NoExtinctionCoefficient as NoExtinctionCoefficient

--- a/src/refractiveindex2/refractiveindex.py
+++ b/src/refractiveindex2/refractiveindex.py
@@ -80,8 +80,11 @@ def _parse_catalog(
                 page_name = page[_page]
                 key = (shelf_name, book_name, page_name)
                 path = page[_data]
-                assert key not in parsed
-                parsed[key] = f"{path_prefix}/{path}"
+                full_path = f"{path_prefix}/{path}"
+                # Duplicate keys are acceptable, but should be consistent.
+                if key in parsed:
+                    assert parsed[key] == full_path
+                parsed[key] = full_path
 
     return parsed
 

--- a/src/refractiveindex2/refractiveindex.py
+++ b/src/refractiveindex2/refractiveindex.py
@@ -64,7 +64,7 @@ def _parse_catalog(
     _page = "PAGE"
     _data = "data"
 
-    parsed = {}
+    parsed: Dict[Tuple[str, str, str], str] = {}
     for shelf in catalog:
         if _shelf not in shelf:
             continue

--- a/tests/test_refractiveindex.py
+++ b/tests/test_refractiveindex.py
@@ -12,12 +12,25 @@ from parameterized import parameterized
 import refractiveindex2 as ri
 
 
+def custom_name_func(testcase_func, param_num, param):
+    # Generate the custom test name from the test arguments.
+    del param_num
+    shelf, book, page = param[0]
+    return f"{testcase_func.__name__}_{shelf}_{book}_{page}"
+
+
 class RefractiveIndexMaterialTest(unittest.TestCase):
-    @parameterized.expand(list(ri.refractiveindex._CATALOG.keys()))
+    @parameterized.expand(
+        list(ri.refractiveindex._CATALOG.keys()),
+        name_func=custom_name_func,
+    )
     def test_can_load_material(self, shelf, book, page):
         ri.RefractiveIndexMaterial(shelf, book, page)
 
-    @parameterized.expand(list(ri.refractiveindex._CATALOG.keys()))
+    @parameterized.expand(
+        list(ri.refractiveindex._CATALOG.keys()),
+        name_func=custom_name_func,
+    )
     def test_can_compute_refractive_index(self, shelf, book, page):
         mat = ri.RefractiveIndexMaterial(shelf, book, page)
         self.assertFalse((mat.n_fn is None) and (mat.k_fn is None))


### PR DESCRIPTION
Recent updates to the refractiveindex.info database have added duplicate keys to the catalog. This should be fine, as long as they are consistent. Here, instead of checking that there are no duplicates, we simply check that any duplicates are consistent.